### PR TITLE
feat: unified Python notifier, Discord thread/wait, INI auto‑patcher, docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Python cache and artifacts
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Virtual environments
+.venv/
+.env/
+.envrc
+
+# Editors/OS
+.vscode/
+.DS_Store

--- a/PI-host/README.md
+++ b/PI-host/README.md
@@ -72,6 +72,29 @@ Discord extras:
 - `DISCORD_WAIT=YES` (optional): Adds `wait=true` to the webhook call so Discord returns a response; useful behind proxies/WAFs.
 - On HTTP 400/401/403 errors with embeds, the script automatically retries with a content-only message. It also prints the HTTP error body to help troubleshoot issues like “Unknown Webhook” (invalid/rotated URL) or permission problems.
 
+### Keep your INI up to date (auto‑patch)
+
+To keep your `log-my-ip.ini` current when new options are introduced, use the helper script `PI-host/update_log_my_ip_ini.py`.
+
+What it does:
+- Preserves all existing values exactly; only appends any missing keys.
+- Adds safe defaults where applicable and commented placeholders for optional keys.
+- Writes a timestamped backup next to your file before saving.
+
+Usage examples:
+
+```sh
+# Preview what would be added, without writing
+python3 PI-host/update_log_my_ip_ini.py --ini /usr/local/etc/log-my-ip.ini --dry-run
+
+# Apply changes (creates a .bak-YYYYmmddHHMMSS backup)
+python3 PI-host/update_log_my_ip_ini.py --ini /usr/local/etc/log-my-ip.ini
+```
+
+Notes:
+- You can run this anytime after pulling updates. It’s idempotent and won’t duplicate keys.
+- Optional keys are appended as commented lines so they don’t change behavior until you opt in.
+
 #### Common OS logo codes
 
 Reference repository: https://github.com/M1XZG/operating-system-logos (see README “Preview List”)

--- a/PI-host/README.md
+++ b/PI-host/README.md
@@ -62,6 +62,8 @@ Unified notifier for Discord and/or Telegram.
   - `--scheduled` sets note to SCHEDULED
   - `-m|--note "custom message"`
   - `--enable-self-update` writes `USE_SELFUPATE=YES` and `GIT_BRANCH="main"` to the INI and exits
+  - `--patch-ini` appends any newly introduced keys to your INI and exits (creates a timestamped .bak backup)
+  - `--patch-ini-preview` previews which keys would be added without writing
   - `--ini /path/to/log-my-ip.ini` to override search
   - `-n|--dry-run` to print without sending
 
@@ -81,7 +83,7 @@ What it does:
 - Adds safe defaults where applicable and commented placeholders for optional keys.
 - Writes a timestamped backup next to your file before saving.
 
-Usage examples:
+Usage examples (standalone helper):
 
 ```sh
 # Preview what would be added, without writing
@@ -89,6 +91,16 @@ python3 PI-host/update_log_my_ip_ini.py --ini /usr/local/etc/log-my-ip.ini --dry
 
 # Apply changes (creates a .bak-YYYYmmddHHMMSS backup)
 python3 PI-host/update_log_my_ip_ini.py --ini /usr/local/etc/log-my-ip.ini
+```
+
+Or use the main script directly:
+
+```sh
+# Preview additions using the active INI resolution
+python3 PI-host/log_my_ip.py --patch-ini-preview
+
+# Apply additions to the currently resolved INI
+python3 PI-host/log_my_ip.py --patch-ini
 ```
 
 Notes:

--- a/PI-host/README.md
+++ b/PI-host/README.md
@@ -67,6 +67,11 @@ Unified notifier for Discord and/or Telegram.
 
 Discord logos: The script picks an OS icon by reading `/etc/os-release` and mapping ID/ID_LIKE to the official alpha-3 codes used by the logos repo. You can override via `DISCORD_OS_LOGO_CODE=UBT` etc. See the repo’s preview list for available codes.
 
+Discord extras:
+- `DISCORD_THREAD_ID` (optional): If your webhook targets a Forum/Thread channel, set the thread ID here so messages go into that thread.
+- `DISCORD_WAIT=YES` (optional): Adds `wait=true` to the webhook call so Discord returns a response; useful behind proxies/WAFs.
+- On HTTP 400/401/403 errors with embeds, the script automatically retries with a content-only message. It also prints the HTTP error body to help troubleshoot issues like “Unknown Webhook” (invalid/rotated URL) or permission problems.
+
 #### Common OS logo codes
 
 Reference repository: https://github.com/M1XZG/operating-system-logos (see README “Preview List”)

--- a/PI-host/README.md
+++ b/PI-host/README.md
@@ -1,7 +1,12 @@
-# Important - Dependencies required
+# PI-host scripts
+
+Host-side scripts for sending IP and system info via Telegram or Discord.
+
+## Important - Dependencies required
 
 The script doesn't rely on too much, however you must have the following installed for it to operate:
 
+* python3
 * curl
 * lsb_release (out of box for Ubuntu, but needs `redhat-lsb-core` for CentOS/RHEL)
 * dig (install `dnsutils` on DEB systems and `bind-utils` on RPM systems)
@@ -10,24 +15,26 @@ The script doesn't rely on too much, however you must have the following install
 
 # How to use this script and supporting files
 
-The way I operate this script is to clone the repo into a folder somewhere, such as in `/root/`, so my folder structure will look like
+Clone the repo into a folder somewhere, such as in `/root/`, so your folder structure looks like
 
 `/root/pi-ip-logging/...`
 
-I do this only because the CRONTAB I've created has directive to run the script `@REBOOT`, this can only be done if the script is run as root. Another reason to run as root is it will attempt to install any dependencies using `apt-get`, at this time the only real dependency is `dnsutils`, most other commands called are stock and found in typical installs.
+Cron entries use `@reboot` which run as root. Adjust paths if you clone elsewhere.
 
 ## Self Updating Script
 
-If you want to use the self-updating function of the script (it's disabled out of the box), then you need to run the script from the cloned repo folder so the GIT data is intact. 
+If you want to use the self-updating function (disabled by default), run from the cloned repo so git metadata is intact.
 
 ## Setting up
 
-I install using the process similar to
+### Install (example)
+
+Install with cron entries for the Python script:
 
 ```
 cd /root
 git clone https://github.com/M1XZG/pi-ip-logging.git
-chmod +x /root/pi-ip-logging/PI-host/log-my-ip.sh
+chmod +x /root/pi-ip-logging/PI-host/log_my_ip.py
 cp /root/pi-ip-logging/PI-host/log-my-ip.CRONTAB /etc/cron.d/log-my-ip
 chmod 644 /etc/cron.d/log-my-ip
 chown root.root /etc/cron.d/log-my-ip
@@ -37,151 +44,90 @@ At this point you should double check `/etc/cron.d/log-my-ip` to make sure the p
 
 ### log-my-ip.ini
 
-This file isn't required if you want to just customize the varibles in the script, however, that will prevent you from using the self-updating part as your changes will be lost to the script. The INI file just contains all the variables required by the script, the default location for this is `/usr/local/etc/log-my-ip.ini`, again, changing this could break. _(I have a future plan to allow the updating of the INI file from perhaps your private webserver or something, GitHub would be bad for this as it will contain secrets you don't want anyone to get)_
+This file contains all variables required by the script. Default search order:
 
-### log-my-ip.sh
+1) `/etc/log-my-ip.ini`
+2) `$HOME/.log-my-ip.ini`
+3) `/usr/local/etc/log-my-ip.ini`
+
+Override with `--ini /path/to/file`.
+
+### Python script (preferred): `log_my_ip.py`
+
+Unified notifier for Discord and/or Telegram.
+
+- ENABLE flags: `ENABLE_DISCORD`, `ENABLE_TELEGRAM` (optional; inferred from config if missing)
+- CLI:
+  - `--reboot` sets note to REBOOT and skips self-update
+  - `--scheduled` sets note to SCHEDULED
+  - `-m|--note "custom message"`
+  - `--enable-self-update` writes `USE_SELFUPATE=YES` and `GIT_BRANCH="main"` to the INI and exits
+  - `--ini /path/to/log-my-ip.ini` to override search
+  - `-n|--dry-run` to print without sending
+
+Discord logos: The script picks an OS icon by reading `/etc/os-release` and mapping ID/ID_LIKE to the official alpha-3 codes used by the logos repo. You can override via `DISCORD_OS_LOGO_CODE=UBT` etc. See the repo’s preview list for available codes.
+
+#### Common OS logo codes
+
+Reference repository: https://github.com/M1XZG/operating-system-logos (see README “Preview List”)
+
+| Code | Name           |
+| ---- | -------------- |
+| UBT  | Ubuntu         |
+| DEB  | Debian         |
+| RHT  | Red Hat (RHEL) |
+| CES  | CentOS         |
+| FED  | Fedora         |
+| ARL  | Arch Linux     |
+| SSE  | SUSE/openSUSE  |
+| RAS  | Raspberry Pi   |
+| MIN  | Linux Mint     |
+| BSD  | FreeBSD        |
+| NBS  | NetBSD         |
+| OBS  | OpenBSD        |
+| WIN  | Windows        |
+| MAC  | Mac            |
+| AND  | Android        |
+| LIN  | GNU/Linux      |
+
+### Legacy bash (still available): `log-my-ip.sh` and `log-my-ip-discord.sh`
 
 This script is run on the Debian linux machines, like the [Raspberry Pi](https://www.raspberrypi.org/) and it will send the hostname, internal IP, external IP and the date/time of the Pi.
 
 To use telegram you will need to create a telegram bot (or use an existing one) and you'll also need the chat / group / channel ID for the bot to receive messages and display them.  There are many guides to figure out how to get the chat id's and such, but check out:
 https://www.home-assistant.io/components/telegram/
 
-The `log-my-ip.sh` script requires no arguements, but whatever you supply will be used as the note that's sent to your or logged. If you look in `/etc/cron.d/log-my-ip` you'll see on reboot the script is called with *REBOOT* and nightly at midnight when I run my daily checkpoint it uses *SCHEDULED*, you can of course change these. If you want to use more than ONE word, just wrap the words in double quotes.
+Arguments behave like the Python script: pass a note, or use flags shown above.
 
 ![Example Telegram Message](../media/telegram-sample.jpg)
 
 This is a run of the script where changes to the repo were found, these are pulled down and the script is run again with the updated version. The `log-my-ip.sh` ins't updated in this run, but other files where, so these are brought down. To have ONLY the script update it would need to be in it's own repo or even a branch of it's own.
 
+## Enabling self-update from CLI
+
+Enable self-update by updating `/usr/local/etc/log-my-ip.ini` (requires root):
+
+```sh
+/root/pi-ip-logging/PI-host/log_my_ip.py --enable-self-update
 ```
-## Using Discord instead of Telegram
 
-If you prefer Discord notifications, use `log-my-ip-discord.sh` which posts to a Discord channel via an Incoming web hook.
+## External IP detection
 
-Setup steps:
+The Python script resolves external IPv4 using multiple strategies:
 
-1) Create a Discord Incoming web hook for your target channel and copy its URL.
-2) Edit or create `/usr/local/etc/log-my-ip.ini` and set:
+1) DNS (if `dig` is available):
+  - Google DNS TXT: `o-o.myaddr.l.google.com @ns1.google.com`
+  - OpenDNS A record: `myip.opendns.com @resolver1.opendns.com`
+2) HTTPS fallbacks: ipify, ifconfig.me, icanhazip, checkip.amazonaws.com, ipinfo.io
 
-   - `DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/…"`
-   - Optionally `DISCORD_USERNAME` and `DISCORD_AVATAR_URL`.
+If all methods fail, `External IP` is set to `Unknown`.
 
-3) Make the script executable and install the CRON file:
+## Cron & environment notes
 
-   - `chmod +x /root/pi-ip-logging/PI-host/log-my-ip-discord.sh`
-   - `cp /root/pi-ip-logging/PI-host/log-my-ip-discord.CRONTAB /etc/cron.d/log-my-ip-discord`
-   # PI-host scripts
+- Colors/tput are disabled when no TTY (cron-safe)
+- Scripts wait for network; on non-LAN hosts set `_my_network_range=ANY` to avoid delays
 
-   Host-side scripts for sending IP and system info via Telegram or Discord.
+## Screenshots
 
-   ## Dependencies
-
-   Install the following on the host:
-
-   - curl
-   - lsb_release (built-in on Ubuntu; use `redhat-lsb-core` for CentOS/RHEL)
-   - dig (install `dnsutils` on DEB systems and `bind-utils` on RPM systems)
-
-   ## Setup
-
-   Clone and install cron entries (example paths assume `/root/pi-ip-logging`):
-
-   ```sh
-   cd /root
-   git clone https://github.com/M1XZG/pi-ip-logging.git
-   chmod +x /root/pi-ip-logging/PI-host/log-my-ip.sh
-   cp /root/pi-ip-logging/PI-host/log-my-ip.CRONTAB /etc/cron.d/log-my-ip
-   chmod 644 /etc/cron.d/log-my-ip
-   chown root.root /etc/cron.d/log-my-ip
-
-   # Discord (optional)
-   chmod +x /root/pi-ip-logging/PI-host/log-my-ip-discord.sh
-   cp /root/pi-ip-logging/PI-host/log-my-ip-discord.CRONTAB /etc/cron.d/log-my-ip-discord
-   chmod 644 /etc/cron.d/log-my-ip-discord
-   chown root.root /etc/cron.d/log-my-ip-discord
-   ```
-
-   Adjust paths in `/etc/cron.d/*` if your clone location differs.
-
-   ## Configuration (log-my-ip.ini)
-
-   Default path is `/usr/local/etc/log-my-ip.ini`. If not present, scripts use built-in defaults.
-
-   Telegram settings:
-
-   - `TGTOKEN` – Bot token
-   - `TGCHATID` – Direct chat ID
-   - `TGGRPID` – Group/channel ID
-
-   Discord settings:
-
-   - `DISCORD_WEBHOOK_URL` – Required for Discord notifications
-   - `DISCORD_USERNAME` – Optional sender name
-   - `DISCORD_AVATAR_URL` – Optional avatar URL
-   - `DISCORD_EMBED_COLOR` – Integer RGB (e.g., 3066993)
-   - `DISCORD_USE_EMBEDS` – YES/NO (default YES)
-
-   Network wait behavior:
-
-   - `_my_network_range` – Prefix to detect local LAN, e.g., `192.168.0` or `172.16.29`
-     - Set to `ANY` or leave empty to accept any non-empty IP (useful on hosted servers)
-   - `NETWORK_WAIT_MAX_ATTEMPTS` – Attempts waiting for a LAN match (5s per attempt), default 24 (~2 minutes)
-
-   Other:
-
-   - `USE_SELFUPATE` – Enable self-update when running from a git clone
-   - `GIT_BRANCH` – Branch to check for updates
-
-   Migration helper:
-
-   - Use `PI-host/migrate-log-my-ip-ini.sh` to safely add new keys without overwriting existing values
-     - `--dry-run` to preview changes
-     - `--from-template` [--template-path /path/to/template] to rebuild from template while preserving known values
-
-   ## Usage
-
-   Telegram script: `log-my-ip.sh`
-
-   - Sends hostname, internal IP, external IP, and date/time via Telegram
-   - Optional post to your server (if configured)
-   - Arguments are used as the note; examples used by cron:
-     - `REBOOT` at startup
-     - `SCHEDULED` nightly
-
-   Discord script: `log-my-ip-discord.sh`
-
-   - Posts to a Discord channel via Incoming Webhook
-   - Rich embeds by default showing: Hostname, Internal IP, External IP, OS, Kernel, Uptime
-   - Accepts notes via positional args or flags: `--reboot`, `--scheduled`, `-m|--note "message"`
-
-  ### Enabling self-update from CLI
-
-  Both scripts can enable self-update by updating `/usr/local/etc/log-my-ip.ini`:
-
-  ```sh
-  # Requires root
-  ./log-my-ip.sh --enable-self-update
-  ./log-my-ip-discord.sh --enable-self-update
-  ```
-
-  This sets `USE_SELFUPATE=YES` and `GIT_BRANCH="main"` in the INI (creating it if missing).
-
-   ## External IP detection
-
-   Both scripts now resolve the external IPv4 using multiple strategies:
-
-   1) DNS (if `dig` is available):
-      - Google DNS TXT: `o-o.myaddr.l.google.com @ns1.google.com`
-      - OpenDNS A record: `myip.opendns.com @resolver1.opendns.com`
-   2) HTTPS fallbacks (via `curl`): ipify, ifconfig.me, icanhazip, checkip.amazonaws.com, ipinfo.io
-
-   If all methods fail, `External IP` is set to `Unknown`.
-
-   ## Cron & environment notes
-
-   - Colors/tput are disabled when no TTY (cron-safe)
-   - Scripts wait for network; on non-LAN hosts set `_my_network_range=ANY` to avoid delays
-
-   ## Screenshots
-
-   ![Example Telegram Message](../media/telegram-sample.jpg)
-   ![Example Telegram Message 2](../media/telegram-sample-2.jpg)
+![Example Telegram Message](../media/telegram-sample.jpg)
+![Example Telegram Message 2](../media/telegram-sample-2.jpg)

--- a/PI-host/log-my-ip.CRONTAB
+++ b/PI-host/log-my-ip.CRONTAB
@@ -1,7 +1,7 @@
 # This file should be should be placed in:   /etc/cron.d/
 # Rename to remove the .CRONTAB (but it's not required, it'll work fine with the current name)
 
-# Run at reboot
-@reboot root /root/pi-ip-logging/PI-host/log-my-ip.sh REBOOT
+# Run at reboot (Python script)
+@reboot root /root/pi-ip-logging/PI-host/log_my_ip.py --reboot
 # Run at a set time each day
-0 0 * * * root /root/pi-ip-logging/PI-host/log-my-ip.sh SCHEDULED
+0 0 * * * root /root/pi-ip-logging/PI-host/log_my_ip.py --scheduled

--- a/PI-host/log-my-ip.ini
+++ b/PI-host/log-my-ip.ini
@@ -45,6 +45,11 @@ DISCORD_EMBED_COLOR=3066993
 # Use rich embeds (YES/NO). Defaults to YES in the script if unset.
 DISCORD_USE_EMBEDS=YES
 
+# Optional: post into a specific thread (e.g., Forum channels) using the thread ID
+#DISCORD_THREAD_ID=
+# Optional: request Discord to return the created message data (may help with some networks)
+#DISCORD_WAIT=YES
+
 # Optional: force a specific OS icon code from the logos repo (alpha-3 code, uppercase).
 # Examples: UBT=Ubuntu, DEB=Debian, RHT=Red Hat, CES=CentOS, FED=Fedora, ARL=Arch Linux,
 #           RAS=Raspberry Pi, MIN=Mint, BSD=FreeBSD, NBS=NetBSD, OBS=OpenBSD, WIN=Windows, MAC=Mac, AND=Android, LIN=GNU/Linux

--- a/PI-host/log-my-ip.ini
+++ b/PI-host/log-my-ip.ini
@@ -1,5 +1,8 @@
-# By default, the script will look for this file in
-# /usr/local/etc/log-my-ip.ini
+# The Python script searches for this file in the following order (first found wins):
+#   1) /etc/log-my-ip.ini
+#   2) $HOME/.log-my-ip.ini
+#   3) /usr/local/etc/log-my-ip.ini
+# You can also explicitly pass --ini /path/to/file when running.
 
 # The idea of this file is so the require variables can be pulled into the script for use
 # but you keep the actual script clean and 'out of the box' as possible. This is important
@@ -30,7 +33,7 @@ _my_network_range="192.168.0"        # Set to "ANY" or leave empty to accept any
 #NETWORK_WAIT_MAX_ATTEMPTS=24
 
 ########################################
-# Discord settings (for log-my-ip-discord.sh)
+# Discord settings (for Python script log_my_ip.py)
 # Set your Discord Incoming Webhook URL. Leave blank to disable Discord notifications.
 DISCORD_WEBHOOK_URL=""                 # e.g. https://discord.com/api/webhooks/xxx/yyy
 # Optional: override the sender name shown in Discord
@@ -41,4 +44,15 @@ DISCORD_AVATAR_URL=""
 DISCORD_EMBED_COLOR=3066993
 # Use rich embeds (YES/NO). Defaults to YES in the script if unset.
 DISCORD_USE_EMBEDS=YES
+
+# Optional: force a specific OS icon code from the logos repo (alpha-3 code, uppercase).
+# Examples: UBT=Ubuntu, DEB=Debian, RHT=Red Hat, CES=CentOS, FED=Fedora, ARL=Arch Linux,
+#           RAS=Raspberry Pi, MIN=Mint, BSD=FreeBSD, NBS=NetBSD, OBS=OpenBSD, WIN=Windows, MAC=Mac, AND=Android, LIN=GNU/Linux
+# See: https://github.com/M1XZG/operating-system-logos (Preview List)
+#DISCORD_OS_LOGO_CODE=UBT
+
+# Enable/disable destinations (optional; if omitted they are inferred from config)
+# Set to YES/NO
+ENABLE_DISCORD=YES
+ENABLE_TELEGRAM=NO
 

--- a/PI-host/log_my_ip.py
+++ b/PI-host/log_my_ip.py
@@ -24,6 +24,7 @@ import time
 from datetime import datetime, timezone
 from typing import Optional
 from urllib import request, parse
+from urllib import error as urlerror
 
 INI_PATH_DEFAULT = "/usr/local/etc/log-my-ip.ini"
 
@@ -345,6 +346,17 @@ def send_discord(cfg, note, hostname, intip, extip, os_name, kernel, uptime, dry
         with request.urlopen(req, timeout=5) as _:
             pass
         return True
+    except urlerror.HTTPError as e:
+        body = None
+        try:
+            body = e.read().decode(errors="ignore")
+        except Exception:
+            body = None
+        if body:
+            print(f"Discord send failed: {e} — {body}", file=sys.stderr)
+        else:
+            print(f"Discord send failed: {e}", file=sys.stderr)
+        return False
     except Exception as e:
         print(f"Discord send failed: {e}", file=sys.stderr)
         return False

--- a/PI-host/log_my_ip.py
+++ b/PI-host/log_my_ip.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python3
+"""
+Unified Python script to send system IP info to Discord and/or Telegram.
+
+- INI discovery (first existing):
+    1) /etc/log-my-ip.ini
+    2) $HOME/.log-my-ip.ini
+    3) /usr/local/etc/log-my-ip.ini
+    Override with --ini /path/to/file
+- ENABLE_DISCORD/ENABLE_TELEGRAM control destinations (inferred if missing)
+- --reboot skips self-update; --scheduled sets note; -m/--note allows custom
+- Waits for internal IP with ANY/timeout behavior; resolves external IP robustly
+- Self-update from git (USE_SELFUPATE=YES, GIT_BRANCH=main), skips if no DNS
+"""
+import argparse
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from urllib import request, parse
+
+INI_PATH_DEFAULT = "/usr/local/etc/log-my-ip.ini"
+
+def resolve_ini_path(cli_path: str | None) -> str:
+    """Resolve the INI path using CLI override or common locations.
+    Order: /etc/log-my-ip.ini, $HOME/.log-my-ip.ini, /usr/local/etc/log-my-ip.ini.
+    If none exist, return /usr/local/etc/log-my-ip.ini as the default target for writes.
+    """
+    if cli_path:
+        # Expand ~ if provided
+        return os.path.expanduser(cli_path)
+    candidates = [
+        "/etc/log-my-ip.ini",
+        os.path.join(os.path.expanduser("~"), ".log-my-ip.ini"),
+        INI_PATH_DEFAULT,
+    ]
+    for p in candidates:
+        try:
+            if os.path.exists(p):
+                return p
+        except Exception:
+            continue
+    return INI_PATH_DEFAULT
+
+def which(cmd):
+    return shutil.which(cmd) is not None
+
+def run(cmd, cwd=None, quiet=True):
+    try:
+        out = subprocess.check_output(cmd, cwd=cwd, stderr=subprocess.DEVNULL if quiet else None)
+        return out.decode().strip()
+    except Exception:
+        return ""
+
+def read_file(path):
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+    except FileNotFoundError:
+        return None
+
+def write_file(path, data, mode=0o644):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(data)
+    os.chmod(path, mode)
+
+def parse_ini(path):
+    cfg = {}
+    text = read_file(path)
+    if not text:
+        return cfg
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, val = line.split("=", 1)
+        key = key.strip()
+        val = val.strip()
+        if len(val) >= 2 and ((val[0] == '"' and val[-1] == '"') or (val[0] == "'" and val[-1] == "'")):
+            val = val[1:-1]
+        cfg[key] = val
+    return cfg
+
+def ensure_ini_enable_flags(cfg):
+    def is_yes(s):
+        return str(s).strip().upper() == "YES"
+    if "ENABLE_DISCORD" in cfg:
+        enable_discord = is_yes(cfg.get("ENABLE_DISCORD"))
+    else:
+        enable_discord = bool(cfg.get("DISCORD_WEBHOOK_URL"))
+    if "ENABLE_TELEGRAM" in cfg:
+        enable_telegram = is_yes(cfg.get("ENABLE_TELEGRAM"))
+    else:
+        t = cfg.get("TGTOKEN")
+        enable_telegram = bool(t and (cfg.get("TGGRPID") or cfg.get("TGCHATID")))
+    return enable_discord, enable_telegram
+
+def wait_for_internal_ip(network_range, max_attempts=24, sleep_sec=5):
+    require_match = not (not network_range or str(network_range).strip().upper() == "ANY")
+    attempts = 0
+    while True:
+        ip = run(["bash", "-lc", "hostname -I | awk '{print $1}'"]) or ""
+        ip = ip.strip()
+        if ip:
+            if not require_match or (network_range in ip):
+                return ip
+        attempts += 1
+        if attempts >= max_attempts:
+            return ip
+        time.sleep(sleep_sec)
+
+def get_external_ip():
+    ipv4_re = re.compile(r"^\d{1,3}(\.\d{1,3}){3}$")
+    if which("dig"):
+        out = run(["dig", "+short", "-4", "TXT", "o-o.myaddr.l.google.com", "@ns1.google.com"]) or ""
+        out = out.replace('"', "").splitlines()[0] if out else ""
+        if ipv4_re.match(out):
+            return out
+        out = run(["dig", "+short", "myip.opendns.com", "@resolver1.opendns.com"]) or ""
+        out = out.splitlines()[0] if out else ""
+        if ipv4_re.match(out):
+            return out
+    urls = [
+        "https://api.ipify.org",
+        "https://ifconfig.me/ip",
+        "https://icanhazip.com",
+        "https://checkip.amazonaws.com",
+        "https://ipinfo.io/ip",
+    ]
+    for url in urls:
+        try:
+            req = request.Request(url, headers={"User-Agent": "pi-ip-logger/1.0"})
+            with request.urlopen(req, timeout=3) as resp:
+                body = resp.read().decode().strip().replace("\n", "").replace("\r", "")
+                if ipv4_re.match(body):
+                    return body
+        except Exception:
+            continue
+    return "Unknown"
+
+def get_os_kernel_uptime():
+    os_name = "Unknown"
+    if which("lsb_release"):
+        out = run(["lsb_release", "-ds"]) or ""
+        os_name = out.strip('"') or "Unknown"
+    else:
+        txt = read_file("/etc/os-release")
+        if txt:
+            for line in txt.splitlines():
+                if line.startswith("PRETTY_NAME="):
+                    os_name = line.split("=", 1)[1].strip().strip('"') or "Unknown"
+                    break
+    kernel = run(["uname", "-r"]) or "Unknown"
+    uptime = run(["bash", "-lc", "uptime -p"]) or "Unknown"
+    return os_name, kernel, uptime
+
+def _read_os_release() -> dict:
+    """Parse /etc/os-release into a dict (best effort)."""
+    info = {}
+    txt = read_file("/etc/os-release")
+    if not txt:
+        return info
+    for line in txt.splitlines():
+        if not line or line.strip().startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        v = v.strip().strip('"')
+        info[k.strip()] = v
+    return info
+
+def get_os_logo_url(cfg: dict, os_name: str) -> str:
+    """Return a logo URL using a short code derived from /etc/os-release or INI override.
+
+    Priority:
+    1) INI override: DISCORD_OS_LOGO_CODE
+    2) /etc/os-release ID
+    3) First of ID_LIKE
+    4) Heuristic fallback from PRETTY_NAME text
+    Codes are normalized to the repo's filename slugs.
+    """
+    # 1) Explicit override
+    override = (cfg.get("DISCORD_OS_LOGO_CODE") or "").strip()
+    if override:
+        code = override.upper()
+        return f"https://raw.githubusercontent.com/M1XZG/operating-system-logos/master/src/128x128/{code}.png"
+
+    # Normalization map from common IDs to logo slugs
+    norm = {
+        # mainstream (alpha3 codes from repo)
+        "ubuntu": "UBT",
+        "debian": "DEB",
+        "raspbian": "RAS",           # Raspberry Pi OS uses Raspberry Pi logo
+        "raspberrypi": "RAS",
+        "raspberry pi os": "RAS",
+        "rhel": "RHT",
+        "redhat": "RHT",
+        "red-hat": "RHT",
+        "centos": "CES",
+        "fedora": "FED",
+        "arch": "ARL",
+        "archlinux": "ARL",
+        # enterprise/derivatives not in list -> fallback to generic Linux
+        "amzn": "LIN",
+        "amazon": "LIN",
+        "amazonlinux": "LIN",
+        "amazon-linux": "LIN",
+        "rocky": "LIN",
+        "rocky-linux": "LIN",
+        "almalinux": "LIN",
+        "alma": "LIN",
+        "opensuse": "SSE",            # Map openSUSE to SUSE
+        "sles": "SSE",
+        "suse": "SSE",
+        "ol": "LIN",                  # Oracle Linux
+        "oracle": "LIN",
+        "oraclelinux": "LIN",
+        "oracle-linux": "LIN",
+        # others
+        "manjaro": "LIN",
+        "kali": "LIN",
+        "gentoo": "GNT",
+        "elementary": "LIN",
+        "elementaryos": "LIN",
+        "linuxmint": "MIN",
+        "mint": "MIN",
+        "pop": "LIN",
+        "pop-os": "LIN",
+        "pop!_os": "LIN",
+        "zorin": "LIN",
+        "void": "LIN",
+        "nixos": "LIN",
+        # platforms
+        "android": "AND",
+        "windows": "WIN",
+        "macos": "MAC",
+        "osx": "MAC",
+        "darwin": "MAC",
+        "linux": "LIN",
+        "freebsd": "BSD",
+        "netbsd": "NBS",
+        "openbsd": "OBS",
+    }
+
+    info = _read_os_release()
+    def to_code(val: str) -> str:
+        return norm.get(val.lower(), "")
+
+    # 2) Try ID
+    code = to_code(info.get("ID", "")) if info else ""
+    if code:
+        return f"https://raw.githubusercontent.com/M1XZG/operating-system-logos/master/src/128x128/{code.upper()}.png"
+    # 3) Try ID_LIKE (space-separated)
+    if info and info.get("ID_LIKE"):
+        for part in info["ID_LIKE"].split():
+            code = to_code(part)
+            if code:
+                return f"https://raw.githubusercontent.com/M1XZG/operating-system-logos/master/src/128x128/{code.upper()}.png"
+    # 4) Fallback heuristic based on name text
+    name = (os_name or "").lower()
+    # Simple keyword heuristics for last-resort mapping
+    keyword_map = {
+        "ubuntu": "UBT",
+        "debian": "DEB",
+        "raspberry": "RAS",
+        "raspbian": "RAS",
+        "red hat": "RHT",
+        "rhel": "RHT",
+        "centos": "CES",
+        "fedora": "FED",
+        "arch": "ARL",
+        "gentoo": "GNT",
+        "mint": "MIN",
+        "suse": "SSE",
+        "opensuse": "SSE",
+        "freebsd": "BSD",
+        "netbsd": "NBS",
+        "openbsd": "OBS",
+        "mac": "MAC",
+        "os x": "MAC",
+        "macos": "MAC",
+        "windows": "WIN",
+        "android": "AND",
+        "linux": "LIN",
+    }
+    for key, val in keyword_map.items():
+        if key in name:
+            return f"https://raw.githubusercontent.com/M1XZG/operating-system-logos/master/src/128x128/{val}.png"
+    return ""
+
+def send_discord(cfg, note, hostname, intip, extip, os_name, kernel, uptime, dry_run=False):
+    url = cfg.get("DISCORD_WEBHOOK_URL", "")
+    if not url:
+        print("Error: DISCORD_WEBHOOK_URL is not configured. Set it in /usr/local/etc/log-my-ip.ini", file=sys.stderr)
+        return False
+    use_embeds = str(cfg.get("DISCORD_USE_EMBEDS", "YES")).strip().upper() != "NO"
+    username = cfg.get("DISCORD_USERNAME", "Pi IP Logger")
+    avatar = cfg.get("DISCORD_AVATAR_URL", "")
+    try:
+        color = int(cfg.get("DISCORD_EMBED_COLOR", "3066993") or "3066993")
+    except Exception:
+        color = 3066993
+    if use_embeds:
+        logo_url = get_os_logo_url(cfg, os_name)
+        payload = {
+            "username": username,
+            "avatar_url": avatar,
+            "embeds": [
+                {
+                    "title": "System Update",
+                    "description": note,
+                    "color": color,
+                    "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                    "author": {"name": hostname},
+                    "footer": {"text": "log-my-ip • Discord"},
+                    **({"thumbnail": {"url": logo_url}} if logo_url else {}),
+                    "fields": [
+                        {"name": "Hostname", "value": hostname, "inline": True},
+                        {"name": "Internal IP", "value": intip or "Unknown", "inline": True},
+                        {"name": "External IP", "value": extip or "Unknown", "inline": True},
+                        {"name": "OS", "value": os_name, "inline": True},
+                        {"name": "Kernel", "value": kernel, "inline": True},
+                        {"name": "Uptime", "value": uptime, "inline": True},
+                    ],
+                }
+            ],
+        }
+    else:
+        content = f"System Update: {note}\nHostname: {hostname}\nInternal IP: {intip}\nExternal IP: {extip}"
+        payload = {"username": username, "avatar_url": avatar, "content": content}
+    data = json.dumps(payload).encode()
+    if dry_run:
+        print("[DRY RUN] Discord payload:", json.dumps(payload))
+        return True
+    try:
+        req = request.Request(url, data=data, headers={"Content-Type": "application/json"})
+        with request.urlopen(req, timeout=5) as _:
+            pass
+        return True
+    except Exception as e:
+        print(f"Discord send failed: {e}", file=sys.stderr)
+        return False
+
+def send_telegram(cfg, note, hostname, intip, extip, dry_run=False):
+    token = cfg.get("TGTOKEN", "")
+    chat_id = cfg.get("TGCHATID", "")
+    grp_id = cfg.get("TGGRPID", "")
+    if not token or not (chat_id or grp_id):
+        print("Warning: Telegram not configured (TGTOKEN + TGGRPID/TGCHATID).", file=sys.stderr)
+        return False
+    msg = f"{note}\nHostname: {hostname}\nInternal IP: {intip}\nExternal IP: {extip}"
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    def post_to(chat):
+        data = parse.urlencode({"chat_id": chat, "text": msg}).encode()
+        if dry_run:
+            print(f"[DRY RUN] Telegram sendMessage to {chat}: {msg}")
+            return True
+        try:
+            req = request.Request(url, data=data, headers={"Content-Type": "application/x-www-form-urlencoded"})
+            with request.urlopen(req, timeout=5) as _:
+                pass
+            return True
+        except Exception as e:
+            print(f"Telegram send failed for {chat}: {e}", file=sys.stderr)
+            return False
+    ok = True
+    if grp_id:
+        ok = post_to(grp_id) and ok
+    if chat_id:
+        ok = post_to(chat_id) and ok
+    return ok
+
+def notify_discord_update(cfg, hostname, branch, old_ref, new_ref):
+    url = cfg.get("DISCORD_WEBHOOK_URL", "")
+    if not url:
+        return
+    payload = {
+        "username": cfg.get("DISCORD_USERNAME", "Pi IP Logger"),
+        "avatar_url": cfg.get("DISCORD_AVATAR_URL", ""),
+        "embeds": [
+            {
+                "title": "Self-update applied",
+                "description": f"Updated on {hostname}",
+                "color": 3447003,
+                "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                "fields": [
+                    {"name": "Branch", "value": branch, "inline": True},
+                    {"name": "Version", "value": f"{old_ref[:7]} → {new_ref[:7]}", "inline": True},
+                ],
+            }
+        ],
+    }
+    try:
+        req = request.Request(url, data=json.dumps(payload).encode(), headers={"Content-Type": "application/json"})
+        request.urlopen(req, timeout=5).read()
+    except Exception:
+        pass
+
+def notify_telegram_update(cfg, hostname, branch, old_ref, new_ref):
+    token = cfg.get("TGTOKEN", "")
+    grp_id = cfg.get("TGGRPID", "") or cfg.get("TGCHATID", "")
+    if not token or not grp_id:
+        return
+    msg = f"Self-update applied on {hostname} (branch {branch}): {old_ref[:7]} -> {new_ref[:7]}"
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    data = parse.urlencode({"chat_id": grp_id, "text": msg}).encode()
+    try:
+        req = request.Request(url, data=data, headers={"Content-Type": "application/x-www-form-urlencoded"})
+        request.urlopen(req, timeout=5).read()
+    except Exception:
+        pass
+
+def can_resolve(host):
+    try:
+        socket.gethostbyname(host)
+        return True
+    except Exception:
+        return False
+
+def self_update_if_needed(cfg, args, hostname):
+    if args.reboot:
+        return
+    if str(cfg.get("USE_SELFUPATE", "NO")).strip().upper() != "YES":
+        return
+    if not which("git"):
+        return
+    if not can_resolve("github.com"):
+        return
+    branch = cfg.get("GIT_BRANCH", "main") or "main"
+    script_abs = os.path.abspath(__file__)
+    repo_dir = os.path.dirname(script_abs)
+    if not run(["git", "rev-parse", "--is-inside-work-tree"], cwd=repo_dir):
+        return
+    run(["git", "fetch", "--all", "--quiet"], cwd=repo_dir)
+    local_before = run(["git", "rev-parse", "--verify", "HEAD"], cwd=repo_dir)
+    remote_target = run(["git", "rev-parse", "--verify", f"origin/{branch}"], cwd=repo_dir)
+    if not local_before or not remote_target or local_before == remote_target:
+        return
+    print("Found a new version of me, updating myself...")
+    run(["git", "checkout", "-q", branch], cwd=repo_dir)
+    run(["git", "pull", "--force", "-q"], cwd=repo_dir)
+    local_after = run(["git", "rev-parse", "--verify", "HEAD"], cwd=repo_dir) or "unknown"
+    enable_discord, enable_telegram = ensure_ini_enable_flags(cfg)
+    if enable_discord:
+        notify_discord_update(cfg, hostname, branch, local_before, local_after)
+    if enable_telegram:
+        notify_telegram_update(cfg, hostname, branch, local_before, local_after)
+    print("Running the new version...")
+    argv = [sys.executable, script_abs] + args.original_argv
+    os.execv(sys.executable, argv)
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Send IP info to Telegram and/or Discord")
+    p.add_argument("-m", "--note", default=None, help="Message to send")
+    p.add_argument("--reboot", action="store_true", help="Use note REBOOT and skip self-update")
+    p.add_argument("--scheduled", action="store_true", help="Use note SCHEDULED")
+    p.add_argument(
+        "--ini",
+        default=None,
+        help=(
+            "Path to INI file (overrides search). Default search order: "
+            "/etc/log-my-ip.ini, $HOME/.log-my-ip.ini, /usr/local/etc/log-my-ip.ini"
+        ),
+    )
+    p.add_argument("-n", "--dry-run", action="store_true", help="Print what would be sent without sending")
+    p.add_argument("--enable-self-update", dest="enable_self_update", action="store_true",
+                   help="Write USE_SELFUPATE=YES and GIT_BRANCH=\"main\" to the INI and exit")
+    args, rest = p.parse_known_args()
+    args.positional = rest
+    args.original_argv = sys.argv[1:]
+    if args.reboot:
+        args.note = "REBOOT"
+    elif args.scheduled:
+        args.note = "SCHEDULED"
+    elif args.note:
+        pass
+    elif args.positional:
+        args.note = " ".join(args.positional)
+    else:
+        args.note = "Manual Update"
+    return args
+
+def ensure_self_update_ini(ini_path):
+    if os.geteuid() != 0:
+        print(f"Must be root to modify {ini_path}", file=sys.stderr)
+        return 1
+    text = read_file(ini_path) or ""
+    lines = [l for l in text.splitlines() if not l.startswith("USE_SELFUPDATE=")]
+    had_use = False
+    had_branch = False
+    new_lines = []
+    for l in lines:
+        if l.startswith("USE_SELFUPATE="):
+            new_lines.append("USE_SELFUPATE=YES")
+            had_use = True
+        elif l.startswith("GIT_BRANCH="):
+            new_lines.append('GIT_BRANCH="main"')
+            had_branch = True
+        else:
+            new_lines.append(l)
+    if not had_use:
+        new_lines.append("USE_SELFUPATE=YES")
+    if not had_branch:
+        new_lines.append('GIT_BRANCH="main"')
+    write_file(ini_path, "\n".join(new_lines) + "\n")
+    print(f"Enabled self-update in {ini_path}")
+    return 0
+
+def main():
+    args = parse_args()
+    ini_path = resolve_ini_path(args.ini)
+    if args.enable_self_update:
+        sys.exit(ensure_self_update_ini(ini_path))
+    cfg = parse_ini(ini_path)
+    enable_discord, enable_telegram = ensure_ini_enable_flags(cfg)
+    hostname = run(["hostname"]) or socket.gethostname()
+    self_update_if_needed(cfg, args, hostname)
+    network_range = cfg.get("_my_network_range", "")
+    max_attempts = int(cfg.get("NETWORK_WAIT_MAX_ATTEMPTS", "24") or "24")
+    intip = wait_for_internal_ip(network_range, max_attempts=max_attempts)
+    extip = get_external_ip()
+    os_name, kernel, uptime = get_os_kernel_uptime()
+    if not (enable_discord or enable_telegram):
+        print(
+            f"No destination enabled. Set ENABLE_DISCORD=YES and/or ENABLE_TELEGRAM=YES in {ini_path}"
+        )
+        return 1
+    ok = True
+    if enable_discord:
+        ok = send_discord(cfg, args.note, hostname, intip, extip, os_name, kernel, uptime, dry_run=args.dry_run) and ok
+    if enable_telegram:
+        ok = send_telegram(cfg, args.note, hostname, intip, extip, dry_run=args.dry_run) and ok
+    return 0 if ok else 2
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/PI-host/log_my_ip.py
+++ b/PI-host/log_my_ip.py
@@ -22,11 +22,12 @@ import subprocess
 import sys
 import time
 from datetime import datetime, timezone
+from typing import Optional
 from urllib import request, parse
 
 INI_PATH_DEFAULT = "/usr/local/etc/log-my-ip.ini"
 
-def resolve_ini_path(cli_path: str | None) -> str:
+def resolve_ini_path(cli_path: Optional[str]) -> str:
     """Resolve the INI path using CLI override or common locations.
     Order: /etc/log-my-ip.ini, $HOME/.log-my-ip.ini, /usr/local/etc/log-my-ip.ini.
     If none exist, return /usr/local/etc/log-my-ip.ini as the default target for writes.

--- a/PI-host/update_log_my_ip_ini.py
+++ b/PI-host/update_log_my_ip_ini.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Auto-patch a log-my-ip.ini file with newly introduced options.
+
+Behavior:
+- Preserves existing values exactly; only appends missing keys near the end.
+- Adds safe defaults or commented placeholders for new options.
+- Backs up the original file to <path>.bak-YYYYmmddHHMMSS
+- Supports --dry-run to preview changes without writing.
+
+Usage:
+  ./update_log_my_ip_ini.py --ini /usr/local/etc/log-my-ip.ini [--dry-run]
+"""
+import argparse
+import os
+import shutil
+import sys
+from datetime import datetime
+from typing import Optional, Dict
+
+
+def read_file(path: str) -> Optional[str]:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+    except FileNotFoundError:
+        return None
+
+
+def write_file(path: str, data: str, mode: int = 0o644) -> None:
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(data)
+    os.chmod(path, mode)
+
+
+def parse_ini_simple(txt: str) -> Dict[str, str]:
+    cfg: Dict[str, str] = {}
+    for raw in txt.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, val = line.split("=", 1)
+        cfg[key.strip()] = val.strip()
+    return cfg
+
+
+def build_missing_lines(existing: Dict[str, str]) -> list:
+    # Define known keys with recommended defaults or commented placeholders.
+    # Keys marked with None will be added as commented-out placeholders.
+    defaults: Dict[str, Optional[str]] = {
+        # Core
+        "USE_SELFUPATE": "NO",
+        "GIT_BRANCH": '"main"',
+        "_my_network_range": '"ANY"',  # Accept any IP by default
+        "NETWORK_WAIT_MAX_ATTEMPTS": None,  # comment-only, default is 24 in code
+
+        # Telegram
+        "TGTOKEN": '""',
+        "TGCHATID": '""',
+        "TGGRPID": '""',
+        "ENABLE_TELEGRAM": None,  # inferred if omitted
+
+        # Discord
+        "DISCORD_WEBHOOK_URL": '""',
+        "DISCORD_USERNAME": '"Pi IP Logger"',
+        "DISCORD_AVATAR_URL": '""',
+        "DISCORD_EMBED_COLOR": "3066993",
+        "DISCORD_USE_EMBEDS": "YES",
+        "DISCORD_OS_LOGO_CODE": None,  # comment-only
+        "DISCORD_THREAD_ID": None,     # comment-only
+        "DISCORD_WAIT": None,          # comment-only
+        "ENABLE_DISCORD": None,        # inferred if omitted
+    }
+
+    lines: list = []
+    for key, val in defaults.items():
+        if key in existing:
+            continue
+        if val is None:
+            # Commented placeholder
+            lines.append(f"#{key}=")
+        else:
+            lines.append(f"{key}={val}")
+    return lines
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Auto-patch log-my-ip.ini with new options")
+    ap.add_argument("--ini", required=True, help="Path to log-my-ip.ini to update")
+    ap.add_argument("--dry-run", action="store_true", help="Show changes without writing")
+    args = ap.parse_args()
+
+    ini_path = os.path.expanduser(args.ini)
+    txt = read_file(ini_path)
+    if txt is None:
+        print(f"Error: INI not found: {ini_path}", file=sys.stderr)
+        return 2
+
+    existing = parse_ini_simple(txt)
+    missing_lines = build_missing_lines(existing)
+
+    if not missing_lines:
+        print("No changes needed — your INI already contains all known keys.")
+        return 0
+
+    # Prepare output
+    banner = [
+        "",
+        f"## Added by update_log_my_ip_ini.py on {datetime.now().isoformat(timespec='seconds')}",
+        "# The following keys were missing and have been appended.",
+        "# Note: commented entries are optional and safe to ignore.",
+    ]
+    new_txt = txt.rstrip("\n") + "\n" + "\n".join(banner + missing_lines) + "\n"
+
+    if args.dry_run:
+        print("--- BEGIN NEW CONTENT (preview) ---")
+        print("\n".join(missing_lines))
+        print("--- END NEW CONTENT (preview) ---")
+        return 0
+
+    # Backup and write
+    backup_path = f"{ini_path}.bak-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+    try:
+        shutil.copy2(ini_path, backup_path)
+        print(f"Backup written: {backup_path}")
+    except Exception as e:
+        print(f"Warning: failed to create backup: {e}")
+    write_file(ini_path, new_txt)
+    print(f"Updated: {ini_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ If you intend to use this, please be sure to fork this to your account. I may ma
 
 ## What?
 
-There are two parts to this project. The main part is the script `PI-host/log-my-ip.sh`, this will send messages to you on Telegram and/or connect to the simple php script `Simple-Serverside/log-ips.php` and dump some basic info in CSV format.
+There are two implementations:
 
-New: If you prefer Discord, use `PI-host/log-my-ip-discord.sh` which posts to a Discord channel via web hook. See `PI-host/README.md` for setup.
+- Preferred: `PI-host/log_my_ip.py` (Python) — unified notifier for Discord and/or Telegram with richer features and easier config.
+- Legacy: `PI-host/log-my-ip.sh` and `PI-host/log-my-ip-discord.sh` (bash) — kept for compatibility.
 
 ## Why?
 
@@ -36,7 +37,9 @@ The script doesn't rely on too much, however you must have the following install
 
 ## PI-host/
 
-See the [README.md](PI-host/README.md) for more usage information.
+See the [PI-host/README.md](PI-host/README.md) for setup, cron examples, and configuration details (including OS logo code overrides for Discord embeds).
+
+OS logo codes reference: https://github.com/M1XZG/operating-system-logos (Preview List)
 
 ---
 


### PR DESCRIPTION
Summary
- Convert to a unified Python script that posts to Discord and Telegram with robust network wait and external IP detection.
- Add Discord features: embeds with OS logo, improved User-Agent, optional thread_id, optional wait=true, and content-only fallback on 4xx.
- Add INI auto‑patcher:
  - Standalone script: PI-host/update_log_my_ip_ini.py
  - Built‑in flags on log_my_ip.py: --patch-ini and --patch-ini-preview
- Improve docs: README updates for configuration, Discord extras, and INI auto‑patch usage.
- Python 3.9+ compatibility (Optional typing fixes).

Notable changes
- New: PI-host/log_my_ip.py (primary script)
- New: PI-host/update_log_my_ip_ini.py (INI auto‑patch helper)
- Updated: PI-host/README.md (usage, Discord extras, auto‑patch docs)
- Updated: PI-host/log-my-ip.ini (documented new options)
- Updated: PI-host/log-my-ip.CRONTAB (Python‑first workflow)

Ops details
- INI discovery: /etc → $HOME → /usr/local with --ini override.
- Self‑update guarded: USE_SELFUPATE=YES, GIT_BRANCH=main; skip on reboot/no DNS.
- External IP: DNS-first (dig) with HTTPS fallbacks.
- Discord resilience: thread_id, wait=true, error body logging, content-only fallback.

How to patch existing INI
- python3 [log_my_ip.py](http://_vscodecontentref_/6) --patch-ini-preview
- python3 [log_my_ip.py](http://_vscodecontentref_/7) --patch-ini
